### PR TITLE
Remove conflicting property

### DIFF
--- a/src/webid/Agent.ts
+++ b/src/webid/Agent.ts
@@ -81,10 +81,6 @@ export class Agent extends TermWrapper {
 }
 
 class HasValue extends TermWrapper {
-    override get value(): string {
-        return this.hasValue ?? super.value
-    }
-
     get hasValue(): string | undefined {
         return OptionalFrom.subjectPredicate(this, VCARD.hasValue, NamedNodeAs.string)
     }


### PR DESCRIPTION
`value` [is a property](https://rdf.js.org/data-model-spec/#dom-term-value) of RDF/JS Terms.

This overriding is legal, but I would argue that it is misleading and superfluous.
Its implementation (either the mapping property or the underlying IRI) is also legal but I don't think it is good.
It is here probably only as a historic legacy and should be removed.