### PR TITLE
fix(wac): Authorization.conforms requires accessTo OR default, not both (#34)

### DIFF
--- a/src/wac/Authorization.ts
+++ b/src/wac/Authorization.ts
@@ -125,7 +125,7 @@ export class Authorization extends TermWrapper {
             return false
         }
 
-        if (this.accessTo === undefined || this.default === undefined) {
+        if (this.accessTo === undefined && this.default === undefined) {
             return false
         }
 

--- a/test/unit/authorization.test.ts
+++ b/test/unit/authorization.test.ts
@@ -1,0 +1,50 @@
+import { DataFactory, Parser, Store } from "n3"
+import assert from "node:assert"
+import { describe, it } from "node:test"
+
+import { Authorization } from "@solid/object"
+
+describe("Authorization.conforms", () => {
+    const sampleRDF = `
+@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
+
+<https://pod.example/.acl#accessToOnly>
+    a acl:Authorization ;
+    acl:accessTo <https://pod.example/note> ;
+    acl:mode acl:Read ;
+    acl:agent <https://alice.example/profile/card#me> .
+
+<https://pod.example/.acl#defaultOnly>
+    a acl:Authorization ;
+    acl:default <https://pod.example/container/> ;
+    acl:mode acl:Read ;
+    acl:agent <https://alice.example/profile/card#me> .
+
+<https://pod.example/.acl#neither>
+    a acl:Authorization ;
+    acl:mode acl:Read ;
+    acl:agent <https://alice.example/profile/card#me> .
+`
+
+    const store = new Store()
+    store.addQuads(new Parser().parse(sampleRDF))
+
+    const authorization = (fragment: string) =>
+        new Authorization(
+            DataFactory.namedNode("https://pod.example/.acl#" + fragment),
+            store,
+            DataFactory
+        )
+
+    it("conforms when only acl:accessTo is present", () => {
+        assert.strictEqual(authorization("accessToOnly").conforms, true)
+    })
+
+    it("conforms when only acl:default is present", () => {
+        assert.strictEqual(authorization("defaultOnly").conforms, true)
+    })
+
+    it("does not conform when neither acl:accessTo nor acl:default is present", () => {
+        assert.strictEqual(authorization("neither").conforms, false)
+    })
+})


### PR DESCRIPTION
## What

Fixes the `Authorization.conforms` logic bug reported in #34: a conforming WAC Authorization must have **at least one of** `acl:accessTo` **or** `acl:default`, but the guard used `||` and so required **both**, wrongly rejecting valid `accessTo`-only and `default`-only Authorizations (the common case in real ACL documents).

```diff
-        if (this.accessTo === undefined || this.default === undefined) {
+        if (this.accessTo === undefined && this.default === undefined) {
```

Per the WAC ["Authorization Conformance"](https://solidproject.org/TR/wac#authorization-conformance) rules: *"At least one `acl:accessTo` or `acl:default` property value."* The guard should reject only when **neither** is present.

## Tests

Adds `test/unit/authorization.test.ts` covering `accessTo`-only → conforms, `default`-only → conforms, and neither → does not conform. Full suite green (`npm test`: 25 pass, 0 fail).

## Note

This is the smaller, non-breaking half. The related #33 (`accessTo`/`default` are single-valued but the RDF predicates are multi-valued) is a **breaking** API change that also touches `wacToAcp`/`acpToWac`, so I left it as an issue for you to decide the preferred API shape — happy to follow up with a PR on confirmation. Once #33 lands and these become sets, this guard becomes `this.accessTo.size === 0 && this.default.size === 0`.

---
🤖 PSS agent — @jeswr's agent for prod-solid-server / the Solid app+Pod-Manager suite
