### PR TITLE
Fix/empty container dataset

### DIFF
--- a/src/solid/ContainerDataset.ts
+++ b/src/solid/ContainerDataset.ts
@@ -5,7 +5,7 @@ import { LDP } from "../vocabulary/mod.js"
 export class ContainerDataset extends DatasetWrapper {
 
     get container(): Container | undefined {
-        // Non-empty containers advertise children via ldp:contains.
+        // Return the first container in the dataset
         for (const s of this.subjectsOf(LDP.contains, Container)) {
             return s
         }

--- a/src/solid/ContainerDataset.ts
+++ b/src/solid/ContainerDataset.ts
@@ -3,10 +3,19 @@ import { Container } from "./Container.js"
 import { LDP } from "../vocabulary/mod.js"
 
 export class ContainerDataset extends DatasetWrapper {
-    // TODO: Consider that this might be undefined if there are no contained resources. We might need different matching.
+
     get container(): Container | undefined {
-        // Return the first container in the dataset
+        // Non-empty containers advertise children via ldp:contains.
         for (const s of this.subjectsOf(LDP.contains, Container)) {
+            return s
+        }
+
+        // Empty containers have no ldp:contains; resolving via rdf:type instead.
+        for (const s of this.instancesOf(LDP.Container, Container)) {
+            return s
+        }
+
+        for (const s of this.instancesOf(LDP.BasicContainer, Container)) {
             return s
         }
 

--- a/src/solid/ContainerDataset.ts
+++ b/src/solid/ContainerDataset.ts
@@ -10,7 +10,9 @@ export class ContainerDataset extends DatasetWrapper {
             return s
         }
 
-        // Empty containers have no ldp:contains; resolving via rdf:type instead.
+        // If the container is empty, then the only instance of `ldp:Container`
+        // and `ldp:BasicContainer` in this dataset should be the container
+        // itself.
         for (const s of this.instancesOf(LDP.Container, Container)) {
             return s
         }

--- a/src/vocabulary/ldp.ts
+++ b/src/vocabulary/ldp.ts
@@ -1,3 +1,5 @@
 export const LDP = {
   contains: "http://www.w3.org/ns/ldp#contains",
+  Container: "http://www.w3.org/ns/ldp#Container",
+  BasicContainer: "http://www.w3.org/ns/ldp#BasicContainer",
 } as const;

--- a/test/unit/container.test.ts
+++ b/test/unit/container.test.ts
@@ -1,0 +1,50 @@
+import { DataFactory, Parser, Store } from "n3";
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { ContainerDataset } from "@solid/object";
+
+describe("ContainerDataset", () => {
+    const emptyContainerRDF = `
+    @prefix dc: <http://purl.org/dc/terms/>.
+    @prefix ldp: <http://www.w3.org/ns/ldp#>.
+    @prefix posix: <http://www.w3.org/ns/posix/stat#>.
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+    <> a ldp:Container, ldp:BasicContainer, ldp:Resource;
+        dc:modified "2026-07-23T10:41:12.846Z"^^xsd:dateTime;
+        posix:mtime 1784803272.
+    `;
+
+    const nonEmptyContainerRDF = `
+    @prefix ldp: <http://www.w3.org/ns/ldp#>.
+    <https://pod.example/container/>
+        a ldp:Container;
+        ldp:contains <https://pod.example/container/file.txt> .
+    <https://pod.example/container/file.txt>
+        a ldp:Resource .
+    `;
+
+    it("resolves an empty container via rdf:type when ldp:contains is absent", () => {
+        const store = new Store();
+        const parser = new Parser({ baseIRI: "https://pod.example/empty/" });
+        store.addQuads(parser.parse(emptyContainerRDF));
+        const dataset = new ContainerDataset(store, DataFactory);
+        const container = dataset.container;
+        assert.ok(container !== undefined);
+        assert.equal(container.id, "https://pod.example/empty/");
+        assert.equal(container.contains.size, 0);
+    });
+
+    it("still resolves a non-empty container via ldp:contains", () => {
+        const store = new Store();
+        store.addQuads(new Parser().parse(nonEmptyContainerRDF));
+        const dataset = new ContainerDataset(store, DataFactory);
+        const container = dataset.container;
+        assert.ok(container !== undefined);
+        assert.equal(container.id, "https://pod.example/container/");
+        assert.equal(container.contains.size, 1);
+        assert.equal(
+            container.contains.values().next().value?.id,
+            "https://pod.example/container/file.txt",
+        );
+    });
+});


### PR DESCRIPTION
## Summary
Empty folders failed because we only looked for containers via `ldp:contains`. 

Related to solid-file-manager [#61](https://github.com/solid-contrib/solid-file-manager/issues/61) and PR [#64 ](https://github.com/solid-contrib/solid-file-manager/pull/64#pullrequestreview-4773907125)review.

I am implementing the fix here, to allow me use this package in the solid file manager