### PR TITLE
Add vocabulary to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     ".": "./dist/mod.js",
     "./acp": "./dist/acp/mod.js",
     "./solid": "./dist/solid/mod.js",
-    "./webid": "./dist/webid/mod.js"
+    "./webid": "./dist/webid/mod.js",
+    "./vocabulary": "./dist/vocabulary/mod.js"
   },
   "files": [
     "dist"

--- a/test/unit/vocabulary.test.ts
+++ b/test/unit/vocabulary.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { ACP } from "@solid/object/vocabulary";
+
+describe("vocabulary export", () => {
+  it("exports ACP IRIs from @solid/object/vocabulary", () => {
+    assert.equal(
+      ACP.AccessControlResource,
+      "http://www.w3.org/ns/solid/acp#AccessControlResource",
+    );
+    assert.equal(ACP.mode, "http://www.w3.org/ns/solid/acp#mode");
+  });
+});


### PR DESCRIPTION
This PR adds @solid/object/vocabulary to the package exports so apps can import IRI constants like ACP instead of maintaining their own vocabulary copies.